### PR TITLE
To resolve issues with installation of dm-acme and scmpy

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,8 @@ cd venvs
 virtualenv sight_env --python=python3.10
 source ~/venvs/sight_env/bin/activate
 
-# Install necessary dependencies from requirement.txt file
+# Install setup.py compatible setuptools and necessary dependencies from requirement.txt file
+pip install setuptools==58.2.0
 pip install -r ~/x-sight/py/sight/requirements.txt
 ```
 Note : if error ```ModuleNotFoundError: No module named 'virtualenv'``` occurs, try installing virtualenv using pip,


### PR DESCRIPTION
We are using two packages, scmpy and dm-acme (the version we use), that use setup.py for their setup. Setup.py is deprecated by setuptools >= 58.3.0. To resolve we can either use newer version of dm-acme (exists) and scmpy (does not exist). For now installing setuptools 58.2.0 for installation works and i have added a line in readme