### PR TITLE
Feature/singleton cache gcs redis

### DIFF
--- a/py/helpers/cache/cache_gcs.py
+++ b/py/helpers/cache/cache_gcs.py
@@ -33,10 +33,11 @@ class GCSCache(CacheInterface):
   _instances = {}
   _lock = threading.Lock()  # to make GCSCache thread-safe
 
-  def __new__(cls, config=None, with_redis_cache: RedisCache = None):
+  def __new__(cls, config=None):
     config = config or {}
+    # The GCSCache instance is unique solely based on 'config'.
+    # 'with_redis_cache' is used only during the first __init__ call for a given config.
     config_key = cls._get_config_hash(config)
-
     with cls._lock:
       if config_key not in cls._instances:
         instance = super(GCSCache, cls).__new__(cls)

--- a/py/helpers/cache/cache_gcs.py
+++ b/py/helpers/cache/cache_gcs.py
@@ -9,9 +9,11 @@ bucket. The base directory is used to separate different types of cached data.
 
 """
 
+import hashlib
 import json
 import pathlib
 import pickle
+import threading
 
 from google.cloud import storage
 from helpers.logs.logs_handler import logger as logging
@@ -28,6 +30,25 @@ from overrides import override
 class GCSCache(CacheInterface):
   """GCS Cache implementation."""
 
+  _instances = {}
+  _lock = threading.Lock()  # to make GCSCache thread-safe
+
+  def __new__(cls, config=None, with_redis_cache: RedisCache = None):
+    config = config or {}
+    config_key = cls._get_config_hash(config)
+
+    with cls._lock:
+      if config_key not in cls._instances:
+        instance = super(GCSCache, cls).__new__(cls)
+        cls._instances[config_key] = instance
+        instance._initialized = False  # so __init__ only runs once per instance
+      return cls._instances[config_key]
+
+  @staticmethod
+  def _get_config_hash(config: dict) -> str:
+    config_str = json.dumps(config, sort_keys=True)
+    return hashlib.sha256(config_str.encode()).hexdigest()
+
   def __init__(self, config=None, with_redis_cache: RedisCache = None):
     """Initializes the GCS Cache.
 
@@ -35,12 +56,16 @@ class GCSCache(CacheInterface):
       config: A dictionary of configuration options.
       with_redis_cache: A RedisCache client to use for caching.
     """
+    if getattr(self, '_initialized', False):
+      return  # prevent re-init
+
     config = config or {}
     gcs_client = storage.Client()
     bucket_name = config.get('gcs_bucket', 'cameltrain-sight')
     self.bucket = gcs_client.bucket(bucket_name=bucket_name)
     self.redis_cache = with_redis_cache
     self.gcs_base_dir = config.get('gcs_base_dir', 'sight_object_storage_cache')
+    self._initialized = True
 
   def _gcs_cache_path(self, key: str, suffix: str = '.json'):
     """Returns the GCS cache path for the given key"""

--- a/py/helpers/cache/cache_redis.py
+++ b/py/helpers/cache/cache_redis.py
@@ -54,9 +54,6 @@ class RedisCache(CacheInterface):
     """
     if getattr(self, '_initialized', False):
       return  # prevent re-init
-
-    if config is None:
-      config = {}
     try:
       self.redis_client = redis.StrictRedis(
           host=config.get("redis_host", RedisConstants.REDIS_HOST),

--- a/py/helpers/cache/cache_redis.py
+++ b/py/helpers/cache/cache_redis.py
@@ -1,7 +1,9 @@
 """This module contains a Redis Cache implementation."""
 
+import hashlib
 import json
 import pickle
+import threading
 
 from helpers.logs.logs_handler import logger as logging
 from overrides import override
@@ -24,6 +26,25 @@ class RedisCache(CacheInterface):
   cache.
   """
 
+  _instances = {}
+  _lock = threading.Lock()  # to make GCSCache thread-safe
+
+  def __new__(cls, config=None):
+    config = config or {}
+    config_key = cls._get_config_hash(config)
+
+    with cls._lock:
+      if config_key not in cls._instances:
+        instance = super(RedisCache, cls).__new__(cls)
+        cls._instances[config_key] = instance
+        instance._initialized = False  # so __init__ only runs once per instance
+      return cls._instances[config_key]
+
+  @staticmethod
+  def _get_config_hash(config: dict) -> str:
+    config_str = json.dumps(config, sort_keys=True)
+    return hashlib.sha256(config_str.encode()).hexdigest()
+
   def __init__(self, config=None):
     """Initializes the RedisCache object.
 
@@ -31,6 +52,9 @@ class RedisCache(CacheInterface):
       config: A dictionary containing configuration options for the Redis
         connection.
     """
+    if getattr(self, '_initialized', False):
+      return  # prevent re-init
+
     if config is None:
       config = {}
     try:
@@ -41,6 +65,7 @@ class RedisCache(CacheInterface):
           db=config.get("redis_db", RedisConstants.REDIS_DB),
       )
       self.redis_client.ping()
+      self._initialized = True
     except (redis.ConnectionError, redis.TimeoutError) as e:
       logging.warning(f"RediConnection failed: {e}")
       self.redis_client = None

--- a/py/helpers/cache/cache_redis.py
+++ b/py/helpers/cache/cache_redis.py
@@ -27,7 +27,7 @@ class RedisCache(CacheInterface):
   """
 
   _instances = {}
-  _lock = threading.Lock()  # to make GCSCache thread-safe
+  _lock = threading.Lock()  # to make RedisCache thread-safe
 
   def __new__(cls, config=None):
     config = config or {}

--- a/py/helpers/cache/tests/integration/test_cache_gcs.py
+++ b/py/helpers/cache/tests/integration/test_cache_gcs.py
@@ -1,7 +1,9 @@
 """Tests for the GCS Cache."""
 
 import json
+import time
 import unittest
+import uuid
 
 from helpers.cache.cache_factory import GCSCache
 from tests.colorful_tests import ColorfulTestRunner
@@ -17,6 +19,68 @@ class CacheGCSTest(unittest.TestCase):
         "gcs_base_dir": "test_sight_cache",
         "gcs_bucket": "cameltrain-sight",
     },)
+
+  def test_singleton_with_same_config(self):
+    config = {
+        "gcs_bucket": "my-test-cache-bucket",  # Replace with real test bucket
+        "gcs_base_dir": f"singleton_test/{uuid.uuid4()}",
+    }
+
+    gcs1 = GCSCache(config)
+    gcs2 = GCSCache(config)
+
+    self.assertIs(
+        gcs1,
+        gcs2,
+        "Two instances with the same config should return the same singleton"
+        " instance.",
+    )
+
+  def test_different_config_returns_different_instance(self):
+    config1 = {
+        "gcs_bucket": "my-test-cache-bucket",  # Replace with real test bucket
+        "gcs_base_dir": f"singleton_test_a/{uuid.uuid4()}",
+    }
+    config2 = {
+        "gcs_bucket": "my-test-cache-bucket",  # Same bucket but different dir
+        "gcs_base_dir": f"singleton_test_b/{uuid.uuid4()}",
+    }
+
+    gcs1 = GCSCache(config1)
+    gcs2 = GCSCache(config2)
+
+    self.assertIsNot(
+        gcs1,
+        gcs2,
+        "Two instances with different config should return different"
+        " instances.",
+    )
+
+  def test_singleton_is_faster_with_same_config(self):
+    base_dir = f"singleton_perf_test/{uuid.uuid4()}"
+    config = {
+        "gcs_bucket": 'test_sight_cache',
+        "gcs_base_dir": base_dir,
+    }
+
+    # First instantiation (cold start)
+    start = time.perf_counter()
+    _ = GCSCache(config)
+    cold_time = time.perf_counter() - start
+
+    # Multiple subsequent calls with same config
+    start = time.perf_counter()
+    for _ in range(1000):
+      _ = GCSCache(config)
+    warm_time = time.perf_counter() - start
+
+    print(f"Cold init time: {cold_time:.6f}s")
+    print(f"Warm repeated init time (1000x): {warm_time:.6f}s")
+
+    self.assertLess(
+        warm_time, cold_time * 5,
+        "Subsequent instantiations with same config should be significantly faster than cold start"
+    )
 
   def test_gcs_get_set(self):
     """Tests the GCS Cache."""

--- a/py/helpers/cache/tests/integration/test_cache_redis.py
+++ b/py/helpers/cache/tests/integration/test_cache_redis.py
@@ -31,89 +31,111 @@ class CacheRedisTest(RedisContainerTest):
     redis_client = self.__class__.redis_client
     redis_client.flushall()
 
-  def test_redis_get_set(self):
-    """Tests the Redis cache."""
-
-    # Configuration for the Redis cache
+  def test_singleton_is_faster_with_same_config(self):
     config = {'redis_host': 'localhost', 'redis_port': 1234, 'redis_db': 0}
-    # Initialize the Redis cache
-    self.cache = RedisCache(config=config)
 
-    self.assertIsNotNone(
-        self.cache.get_redis_client(),
-        'Cache client is not found , check your redis connection !!',
+    # First instantiation (cold start)
+    start = time.perf_counter()
+    _ = RedisCache(config)
+    cold_time = time.perf_counter() - start
+
+    # Multiple subsequent calls with same config
+    start = time.perf_counter()
+    for _ in range(1000):
+      _ = RedisCache(config)
+    warm_time = time.perf_counter() - start
+
+    print(f"Cold init time: {cold_time:.6f}s")
+    print(f"Warm repeated init time (1000x): {warm_time:.6f}s")
+
+    self.assertLess(
+        warm_time, cold_time * 50,
+        "Subsequent instantiations with same config should be significantly faster than cold start"
     )
 
-    # Set data in the Redis cache
-    self.cache.set('testing:test1:0', json.dumps({'Fire': [2023, 2034, 3004]}))
+  # def test_redis_get_set(self):
+  #   """Tests the Redis cache."""
 
-    # Retrieve data from the Redis cache
-    result = self.cache.get('testing:test1:0')
-    result = json.loads(result)
-    # Assert the retrieved data is correct
-    expected_result = {'Fire': [2023, 2034, 3004]}
-    self.assertEqual(result, expected_result,
-                     f'Expected {expected_result}, but got {result}')
+  #   # Configuration for the Redis cache
+  #   config = {'redis_host': 'localhost', 'redis_port': 1234, 'redis_db': 0}
+  #   # Initialize the Redis cache
+  #   self.cache = RedisCache(config=config)
 
-  def test_reds_json_get_set(self):
-    """Tests the Redis cache."""
+  #   self.assertIsNotNone(
+  #       self.cache.get_redis_client(),
+  #       'Cache client is not found , check your redis connection !!',
+  #   )
 
-    # Configuration for the Redis cache
-    config = {'redis_host': 'localhost', 'redis_port': 1234, 'redis_db': 0}
-    # Initialize the Redis cache
-    self.cache = RedisCache(config=config)
+  #   # Set data in the Redis cache
+  #   self.cache.set('testing:test1:0', json.dumps({'Fire': [2023, 2034, 3004]}))
 
-    self.assertIsNotNone(
-        self.cache.get_redis_client(),
-        'Cache client is not found , check your redis connection !!',
-    )
+  #   # Retrieve data from the Redis cache
+  #   result = self.cache.get('testing:test1:0')
+  #   result = json.loads(result)
+  #   # Assert the retrieved data is correct
+  #   expected_result = {'Fire': [2023, 2034, 3004]}
+  #   self.assertEqual(result, expected_result,
+  #                    f'Expected {expected_result}, but got {result}')
 
-    # Set data in the Redis cache
-    self.cache.json_set('testing:test:1', {'Fire': [2023, 2034, 3004]})
+  # def test_reds_json_get_set(self):
+  #   """Tests the Redis cache."""
 
-    # Retrieve data from the Redis cache
-    result = self.cache.json_get('testing:test:1')
+  #   # Configuration for the Redis cache
+  #   config = {'redis_host': 'localhost', 'redis_port': 1234, 'redis_db': 0}
+  #   # Initialize the Redis cache
+  #   self.cache = RedisCache(config=config)
 
-    # Assert the retrieved data is correct
-    expected_result = {'Fire': [2023, 2034, 3004]}
-    self.assertEqual(result, expected_result,
-                     f'Expected {expected_result}, but got {result}')
+  #   self.assertIsNotNone(
+  #       self.cache.get_redis_client(),
+  #       'Cache client is not found , check your redis connection !!',
+  #   )
 
-  def test_redis_via_factory(self):
+  #   # Set data in the Redis cache
+  #   self.cache.json_set('testing:test:1', {'Fire': [2023, 2034, 3004]})
 
-    self.cache = CacheFactory.get_cache('redis', {
-        'redis_host': 'localhost',
-        'redis_port': 1234,
-        'redis_db': 0
-    })
-    self.cache.json_set('testing:factory:0', json.dumps({'welcome': 'back'}))
-    self.assertEqual({'welcome': 'back'},
-                     json.loads(self.cache.json_get('testing:factory:0')))
+  #   # Retrieve data from the Redis cache
+  #   result = self.cache.json_get('testing:test:1')
 
-  def test_redis_bin_get_set(self):
-    # Configuration for the Redis cache
-    config = {'redis_host': 'localhost', 'redis_port': 1234, 'redis_db': 0}
-    # Initialize the Redis cache
-    self.cache = RedisCache(config=config)
+  #   # Assert the retrieved data is correct
+  #   expected_result = {'Fire': [2023, 2034, 3004]}
+  #   self.assertEqual(result, expected_result,
+  #                    f'Expected {expected_result}, but got {result}')
 
-    self.assertIsNotNone(
-        self.cache.get_redis_client(),
-        'Cache client is not found , check your redis connection !!',
-    )
+  # def test_redis_via_factory(self):
 
-    # Set data in the Redis cache
-    self.cache.bin_set(
-        'testing:test:2',
-        {'Fire': [2023, 2034, 3004]},
-    )
+  #   self.cache = CacheFactory.get_cache('redis', {
+  #       'redis_host': 'localhost',
+  #       'redis_port': 1234,
+  #       'redis_db': 0
+  #   })
+  #   self.cache.json_set('testing:factory:0', json.dumps({'welcome': 'back'}))
+  #   self.assertEqual({'welcome': 'back'},
+  #                    json.loads(self.cache.json_get('testing:factory:0')))
 
-    # Retrieve data from the Redis cache
-    result = self.cache.bin_get('testing:test:2')
+  # def test_redis_bin_get_set(self):
+  #   # Configuration for the Redis cache
+  #   config = {'redis_host': 'localhost', 'redis_port': 1234, 'redis_db': 0}
+  #   # Initialize the Redis cache
+  #   self.cache = RedisCache(config=config)
 
-    # Assert the retrieved data is correct
-    expected_result = {'Fire': [2023, 2034, 3004]}
-    self.assertEqual(result, expected_result,
-                     f'Expected {expected_result}, but got {result}')
+  #   self.assertIsNotNone(
+  #       self.cache.get_redis_client(),
+  #       'Cache client is not found , check your redis connection !!',
+  #   )
+
+  #   # Set data in the Redis cache
+  #   self.cache.bin_set(
+  #       'testing:test:2',
+  #       {'Fire': [2023, 2034, 3004]},
+  #   )
+
+  #   # Retrieve data from the Redis cache
+  #   result = self.cache.bin_get('testing:test:2')
+
+  #   # Assert the retrieved data is correct
+  #   expected_result = {'Fire': [2023, 2034, 3004]}
+  #   self.assertEqual(result, expected_result,
+  #                    f'Expected {expected_result}, but got {result}')
 
 
 if __name__ == '__main__':

--- a/py/helpers/cache/tests/integration/test_cache_redis.py
+++ b/py/helpers/cache/tests/integration/test_cache_redis.py
@@ -53,89 +53,89 @@ class CacheRedisTest(RedisContainerTest):
         "Subsequent instantiations with same config should be significantly faster than cold start"
     )
 
-  # def test_redis_get_set(self):
-  #   """Tests the Redis cache."""
+  def test_redis_get_set(self):
+    """Tests the Redis cache."""
 
-  #   # Configuration for the Redis cache
-  #   config = {'redis_host': 'localhost', 'redis_port': 1234, 'redis_db': 0}
-  #   # Initialize the Redis cache
-  #   self.cache = RedisCache(config=config)
+    # Configuration for the Redis cache
+    config = {'redis_host': 'localhost', 'redis_port': 1234, 'redis_db': 0}
+    # Initialize the Redis cache
+    self.cache = RedisCache(config=config)
 
-  #   self.assertIsNotNone(
-  #       self.cache.get_redis_client(),
-  #       'Cache client is not found , check your redis connection !!',
-  #   )
+    self.assertIsNotNone(
+        self.cache.get_redis_client(),
+        'Cache client is not found , check your redis connection !!',
+    )
 
-  #   # Set data in the Redis cache
-  #   self.cache.set('testing:test1:0', json.dumps({'Fire': [2023, 2034, 3004]}))
+    # Set data in the Redis cache
+    self.cache.set('testing:test1:0', json.dumps({'Fire': [2023, 2034, 3004]}))
 
-  #   # Retrieve data from the Redis cache
-  #   result = self.cache.get('testing:test1:0')
-  #   result = json.loads(result)
-  #   # Assert the retrieved data is correct
-  #   expected_result = {'Fire': [2023, 2034, 3004]}
-  #   self.assertEqual(result, expected_result,
-  #                    f'Expected {expected_result}, but got {result}')
+    # Retrieve data from the Redis cache
+    result = self.cache.get('testing:test1:0')
+    result = json.loads(result)
+    # Assert the retrieved data is correct
+    expected_result = {'Fire': [2023, 2034, 3004]}
+    self.assertEqual(result, expected_result,
+                     f'Expected {expected_result}, but got {result}')
 
-  # def test_reds_json_get_set(self):
-  #   """Tests the Redis cache."""
+  def test_reds_json_get_set(self):
+    """Tests the Redis cache."""
 
-  #   # Configuration for the Redis cache
-  #   config = {'redis_host': 'localhost', 'redis_port': 1234, 'redis_db': 0}
-  #   # Initialize the Redis cache
-  #   self.cache = RedisCache(config=config)
+    # Configuration for the Redis cache
+    config = {'redis_host': 'localhost', 'redis_port': 1234, 'redis_db': 0}
+    # Initialize the Redis cache
+    self.cache = RedisCache(config=config)
 
-  #   self.assertIsNotNone(
-  #       self.cache.get_redis_client(),
-  #       'Cache client is not found , check your redis connection !!',
-  #   )
+    self.assertIsNotNone(
+        self.cache.get_redis_client(),
+        'Cache client is not found , check your redis connection !!',
+    )
 
-  #   # Set data in the Redis cache
-  #   self.cache.json_set('testing:test:1', {'Fire': [2023, 2034, 3004]})
+    # Set data in the Redis cache
+    self.cache.json_set('testing:test:1', {'Fire': [2023, 2034, 3004]})
 
-  #   # Retrieve data from the Redis cache
-  #   result = self.cache.json_get('testing:test:1')
+    # Retrieve data from the Redis cache
+    result = self.cache.json_get('testing:test:1')
 
-  #   # Assert the retrieved data is correct
-  #   expected_result = {'Fire': [2023, 2034, 3004]}
-  #   self.assertEqual(result, expected_result,
-  #                    f'Expected {expected_result}, but got {result}')
+    # Assert the retrieved data is correct
+    expected_result = {'Fire': [2023, 2034, 3004]}
+    self.assertEqual(result, expected_result,
+                     f'Expected {expected_result}, but got {result}')
 
-  # def test_redis_via_factory(self):
+  def test_redis_via_factory(self):
 
-  #   self.cache = CacheFactory.get_cache('redis', {
-  #       'redis_host': 'localhost',
-  #       'redis_port': 1234,
-  #       'redis_db': 0
-  #   })
-  #   self.cache.json_set('testing:factory:0', json.dumps({'welcome': 'back'}))
-  #   self.assertEqual({'welcome': 'back'},
-  #                    json.loads(self.cache.json_get('testing:factory:0')))
+    self.cache = CacheFactory.get_cache('redis', {
+        'redis_host': 'localhost',
+        'redis_port': 1234,
+        'redis_db': 0
+    })
+    self.cache.json_set('testing:factory:0', json.dumps({'welcome': 'back'}))
+    self.assertEqual({'welcome': 'back'},
+                     json.loads(self.cache.json_get('testing:factory:0')))
 
-  # def test_redis_bin_get_set(self):
-  #   # Configuration for the Redis cache
-  #   config = {'redis_host': 'localhost', 'redis_port': 1234, 'redis_db': 0}
-  #   # Initialize the Redis cache
-  #   self.cache = RedisCache(config=config)
+  def test_redis_bin_get_set(self):
+    # Configuration for the Redis cache
+    config = {'redis_host': 'localhost', 'redis_port': 1234, 'redis_db': 0}
+    # Initialize the Redis cache
+    self.cache = RedisCache(config=config)
 
-  #   self.assertIsNotNone(
-  #       self.cache.get_redis_client(),
-  #       'Cache client is not found , check your redis connection !!',
-  #   )
+    self.assertIsNotNone(
+        self.cache.get_redis_client(),
+        'Cache client is not found , check your redis connection !!',
+    )
 
-  #   # Set data in the Redis cache
-  #   self.cache.bin_set(
-  #       'testing:test:2',
-  #       {'Fire': [2023, 2034, 3004]},
-  #   )
+    # Set data in the Redis cache
+    self.cache.bin_set(
+        'testing:test:2',
+        {'Fire': [2023, 2034, 3004]},
+    )
 
-  #   # Retrieve data from the Redis cache
-  #   result = self.cache.bin_get('testing:test:2')
+    # Retrieve data from the Redis cache
+    result = self.cache.bin_get('testing:test:2')
 
-  #   # Assert the retrieved data is correct
-  #   expected_result = {'Fire': [2023, 2034, 3004]}
-  #   self.assertEqual(result, expected_result,
-  #                    f'Expected {expected_result}, but got {result}')
+    # Assert the retrieved data is correct
+    expected_result = {'Fire': [2023, 2034, 3004]}
+    self.assertEqual(result, expected_result,
+                     f'Expected {expected_result}, but got {result}')
 
 
 if __name__ == '__main__':

--- a/py/helpers/cache/tests/integration/test_cache_redis.py
+++ b/py/helpers/cache/tests/integration/test_cache_redis.py
@@ -31,6 +31,37 @@ class CacheRedisTest(RedisContainerTest):
     redis_client = self.__class__.redis_client
     redis_client.flushall()
 
+  def test_singleton_with_same_config(self):
+    config = {'redis_host': 'localhost', 'redis_port': 1234, 'redis_db': 0}
+
+    redis1 = RedisCache(config)
+    redis2 = RedisCache(config)
+
+    self.assertIs(
+        redis1,
+        redis2,
+        "Two instances with the same config should return the same singleton"
+        " instance.",
+    )
+
+  def test_different_config_returns_different_instance(self):
+    config1 = {'redis_host': 'localhost', 'redis_port': 1234, 'redis_db': 0}
+    config2 = {
+        'redis_host': 'localhost',
+        'redis_port': 1234,
+        'redis_db': 1
+    }  # Different DB
+
+    redis1 = RedisCache(config1)
+    redis2 = RedisCache(config2)
+
+    self.assertIsNot(
+        redis1,
+        redis2,
+        "Two instances with different config should return different"
+        " instances.",
+    )
+
   def test_singleton_is_faster_with_same_config(self):
     config = {'redis_host': 'localhost', 'redis_port': 1234, 'redis_db': 0}
 
@@ -41,7 +72,7 @@ class CacheRedisTest(RedisContainerTest):
 
     # Multiple subsequent calls with same config
     start = time.perf_counter()
-    for _ in range(1000):
+    for _ in range(100):
       _ = RedisCache(config)
     warm_time = time.perf_counter() - start
 


### PR DESCRIPTION
feat(cache): apply singleton pattern to GCSCache and RedisCache

## 🔄 Summary

Refactored `GCSCache` and `RedisCache` to follow the **singleton pattern**,
using a `sha256` hash of the config as a unique key. This avoids redundant
client creation and improves efficiency.

---

## ✅ What’s Changed

- Overrode `__new__` to return the same instance for identical configs.
- Used `sha256(config)` as the cache key.
- Ensured `__init__` only runs once per config.
- Updated `unittest` integration tests to verify:
  - Singleton behavior
  - Cache operations work correctly

---

## 💡 Why

- Reduces unnecessary Redis/GCS client reinitialization.
- Speeds up repeated cache usage.
- Keeps resource usage low in high-frequency environments.

---

## 🧪 Test

```bash
python -m unittest discover ~/Desktop/x-kokua/sightRepo/py/helpers/cache/tests/integration
```


<img width="917" height="471" alt="image" src="https://github.com/user-attachments/assets/ae78547f-b650-4d61-aa1c-7d0cb40dd957" />
