### PR TITLE
[tf] write structured logs to cliud logging

### DIFF
--- a/py/sight/sight.py
+++ b/py/sight/sight.py
@@ -26,6 +26,9 @@ import random
 import threading
 import time
 import json
+
+from google.cloud import logging_v2
+
 from typing import Any, Optional, Sequence, Callable, Union
 
 from absl import flags
@@ -785,10 +788,49 @@ class Sight(object):
     self.avro_record_counter += 1
     if self.avro_record_counter % 1000 == 0:
       self._upload_avro_file_to_gcs()
+      self._upload_avro_file_to_cloud_logging()
+    
+  def _upload_avro_file_to_cloud_logging(self):
+    original_position = self.avro_log.tell()
+    try:
+        # TODO: add managed connection pooling for high volume callers
+        project_id = os.environ['PROJECT_ID']
+        client = logging_v2.Client(project=project_id)
+        self.avro_log.seek(0)
+        buffer_content = self.avro_log.read()
+
+        # TODO: implement non blocking decoding for large (> 1gb) files
+        content_string = buffer_content.decode('utf-8', 'ignore')
+
+        payload = {
+            "message": content_string,
+        }
+
+        log_path = f"projects/{project_id}/logs/sight"
+
+        entry = logging_v2.types.LogEntry(
+            log_name=log_path,
+            severity="INFO",
+            json_payload=payload
+        )
+
+        # This is a direct API call and does NOT use the standard Python logging system.
+        client.logging_service.write_log_entries(
+            entries=[entry],
+        )
+
+    except Exception as e:
+        print(f"An error occurred during logging to Cloud Logging: {e}")
+
+    finally:
+        self.avro_log.seek(original_position)
+
 
   def _flush_log(self):
     """Flushes the log to remote storage."""
     if self.avro_log:
+      # Order matters. The _upload_avro_file_to_gcs is destructive.
+      self._upload_avro_file_to_cloud_logging()
       self._upload_avro_file_to_gcs()
 
   def log_object(self,

--- a/py/sight/sight.py
+++ b/py/sight/sight.py
@@ -787,8 +787,8 @@ class Sight(object):
     fastavro.writer(self.avro_log, self.avro_schema, [dict_obj])
     self.avro_record_counter += 1
     if self.avro_record_counter % 1000 == 0:
-      self._upload_avro_file_to_gcs()
       self._upload_avro_file_to_cloud_logging()
+      self._upload_avro_file_to_gcs()
     
   def _upload_avro_file_to_cloud_logging(self):
     original_position = self.avro_log.tell()


### PR DESCRIPTION
## background

We want to selectively write the fully hydrated suite of related logs to cloud logging as one obj. We implement this in places where 1) avros logging is demanded, 2) callers demand the log be flushed, and/or 3) on Sight close. We do so without destroying the buffer but without creating yet another copy of the log. We take on the pattern of creating a client at call time (like the other gcs utils), but given the freq of this operation, it might make sense to add some connection pooling out of the box for callers. We intentionally do not take over the main python logger so the sight application logs should only contain fully hydrated sight structured logs, not application level logs. 

We can write application logs to cloud logging as well and write those to a separate sink by just adding this to the main function. https://cloud.google.com/logging/docs/setup/python#write_logs_with_the_standard_python_logging_handler

## changes

[py/sight] create a function that creates structured logs from the avro file and writes it to cloud logging

## notes for reviewer

We would like to implement some special querying functionality. Right now we just include the entire object as payload. We want to take out a few select features from the log to allow top level searching - namely, job id. 